### PR TITLE
Edisp scale option was included

### DIFF
--- a/Scale_IRFs.py
+++ b/Scale_IRFs.py
@@ -102,6 +102,29 @@ if __name__ == "__main__":
     print("")
     # -------------------------
 
+    # -------------------------
+    print("  Energy Dispersion:")
+    print("    Energy scaling:")
+
+    err_func_type = config['edisp']['energy_scaling']['err_func_type']
+    scale_params = config['edisp']['energy_scaling'][err_func_type]
+
+    print("      {:.<23s}:  {:s}".format('err_func_type', err_func_type))
+    for key in scale_params:
+        print("      {:.<23s}:  {}".format(key, scale_params[key]))
+
+    print("    Angular scaling:")
+
+    err_func_type = config['edisp']['angular_scaling']['err_func_type']
+    scale_params = config['edisp']['angular_scaling'][err_func_type]
+
+    print("      {:.<23s}:  {:s}".format('err_func_type', err_func_type))
+    for key in scale_params:
+        print("      {:.<23s}:  {}".format(key, scale_params[key]))
+        
+    print("")
+    # -------------------------
+
     # Scale IRF
     caldb_path = os.environ['CALDB']
 
@@ -111,14 +134,17 @@ if __name__ == "__main__":
 
     # Plot
     if plot_aeff_scale_map:
-        pyplot.figure(figsize=(10, 4))
+        pyplot.figure(figsize=(15, 4))
         pyplot.clf()
 
-        pyplot.subplot(121)
+        pyplot.subplot(131)
         caldb.plot_aeff_scale_map()
 
-        pyplot.subplot(122)
+        pyplot.subplot(132)
         caldb.plot_psf_scale_map()
+
+        pyplot.subplot(133)
+        caldb.plot_edisp_scale_map()
 
         pyplot.tight_layout()
         pyplot.show()

--- a/config.yaml
+++ b/config.yaml
@@ -29,7 +29,7 @@ aeff:
     # Angular scaling
     angular_scaling:
         # Choices: 'constant', 'gradient', 'step'
-        err_func_type: 'step'
+        err_func_type: 'gradient'
         constant:
             scale: 1.0
         gradient:
@@ -69,6 +69,40 @@ psf:
         gradient:
             scale: 0.1
             range_min: 0.0  # deg
+            range_max: 7.6  # deg
+        step:
+            scale: 0.1
+            transition_pos: [2.0, 4.0]  # deg
+            transition_widths: [0.1, 0.1]  # deg
+
+# Edisp specific
+edisp:
+    #Scaling
+    energy_scaling:
+        # Choices: 'constant', 'gradient', 'step'
+        err_func_type: 'gradient'
+        constant:
+          scale: 1.0
+        gradient:
+            scale: 0.1
+            range_min: 0.02  # TeV
+            range_max: 300.0  # TeV
+        step:
+            scale: 0.5
+            # Transition energies in TeV
+            transition_pos: [0.15, 5.0]
+            # Log10 transition widths (to be determined from IRF)
+            transition_widths: [0.11, 0.06]
+    # Angular scaling
+    angular_scaling:
+        # Choices: 'constant', 'gradient', 'step'
+        err_func_type: 'step'
+        constant:
+            scale: 1.0
+        gradient:
+            scale: 0.1
+
+            range_min: 0.1  # deg
             range_max: 7.6  # deg
         step:
             scale: 0.1


### PR DESCRIPTION
Main changes are as follows:
Scale_IRFs.py : 
The 'print Edisp parameters' lines were added.
The plot was extended to include a third  plot.
caldb_scaler.py:
_scale_edisp was defined to scale the Migration Matrix
get_edip_scale_map was introduced to establish the Edisp plot
plot_edis_scale_map was introduced to make the plot. 
config.yaml
Edisp specific scale options were added 